### PR TITLE
Update links to point to the new repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ## 0.3.0
 
-([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/v0.2.0...8e56ca1c3ee5e81f725cf8b57198c5b6d301c935))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/compare/v0.2.0...8e56ca1c3ee5e81f725cf8b57198c5b6d301c935))
 
 ### Merged PRs
 
-- Implement newUntitled [#14](https://github.com/jtpio/jupyterlab-filesystem-access/pull/14) ([@martinRenou](https://github.com/martinRenou))
+- Implement newUntitled [#14](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/14) ([@martinRenou](https://github.com/martinRenou))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-11&to=2022-04-12&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-11&to=2022-04-12&type=c))
 
 [@martinRenou](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3AmartinRenou+updated%3A2022-04-11..2022-04-12&type=Issues)
 
@@ -20,51 +20,51 @@
 
 ## 0.2.0
 
-([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/v0.1.1...b776fa853b8e6a3a6a3990278a9987f56f6e77a5))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/compare/v0.1.1...b776fa853b8e6a3a6a3990278a9987f56f6e77a5))
 
 ### Enhancements made
 
-- Add support opening subdirs [#11](https://github.com/jtpio/jupyterlab-filesystem-access/pull/11) ([@martinRenou](https://github.com/martinRenou))
+- Add support opening subdirs [#11](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/11) ([@martinRenou](https://github.com/martinRenou))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-09&to=2022-04-11&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-09&to=2022-04-11&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-09..2022-04-11&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3AmartinRenou+updated%3A2022-04-09..2022-04-11&type=Issues)
 
 ## 0.1.1
 
-([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/v0.1.0...3d9774618956b282ebb9f3498c6e0f3731dea86d))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/compare/v0.1.0...3d9774618956b282ebb9f3498c6e0f3731dea86d))
 
 ### Bugs fixed
 
-- Fix saving Notebooks [#9](https://github.com/jtpio/jupyterlab-filesystem-access/pull/9) ([@jtpio](https://github.com/jtpio))
+- Fix saving Notebooks [#9](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/9) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-09&to=2022-04-09&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-09&to=2022-04-09&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-09..2022-04-09&type=Issues)
 
 ## 0.1.0
 
-([Full Changelog](https://github.com/jtpio/jupyterlab-filesystem-access/compare/cec8cbbce5042c8f7d6dce07265fba5a5317c8df...bbc9d3597d0694178d96c00268ff6d501b6a1268))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/compare/cec8cbbce5042c8f7d6dce07265fba5a5317c8df...bbc9d3597d0694178d96c00268ff6d501b6a1268))
 
 ### Enhancements made
 
-- Basic support for saving a file [#5](https://github.com/jtpio/jupyterlab-filesystem-access/pull/5) ([@jtpio](https://github.com/jtpio))
+- Basic support for saving a file [#5](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/5) ([@jtpio](https://github.com/jtpio))
 
 ### Maintenance and upkeep improvements
 
-- Reset version [#7](https://github.com/jtpio/jupyterlab-filesystem-access/pull/7) ([@jtpio](https://github.com/jtpio))
-- Rename to `jupyterlab-filesystem-access` [#6](https://github.com/jtpio/jupyterlab-filesystem-access/pull/6) ([@jtpio](https://github.com/jtpio))
+- Reset version [#7](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/7) ([@jtpio](https://github.com/jtpio))
+- Rename to `jupyterlab-filesystem-access` [#6](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/6) ([@jtpio](https://github.com/jtpio))
 
 ### Documentation improvements
 
-- Add disclaimer to README.md [#4](https://github.com/jtpio/jupyterlab-filesystem-access/pull/4) ([@jtpio](https://github.com/jtpio))
+- Add disclaimer to README.md [#4](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/4) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-08&to=2022-04-09&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-08&to=2022-04-09&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-08..2022-04-09&type=Issues)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-filesystem-access
 
-[![Github Actions Status](https://github.com/jtpio/jupyterlab-filesystem-access/workflows/Build/badge.svg)](https://github.com/jtpio/jupyterlab-filesystem-access/actions/workflows/build.yml)
+[![Github Actions Status](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/workflows/Build/badge.svg)](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/actions/workflows/build.yml)
 
 Browse local files using the non-standard Web Browser File System Access API.
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/jtpio/jupyterlab-filesystem-access",
+  "homepage": "https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access",
   "bugs": {
-    "url": "https://github.com/jtpio/jupyterlab-filesystem-access/issues"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -25,7 +25,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jtpio/jupyterlab-filesystem-access.git"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access.git"
   },
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab-contrib/jupyterlab-contrib.github.io/issues/31