### PR TITLE
Automated Changelog Entry for 0.4.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.0
+
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/compare/v0.3.0...57ecfc93de1c9b2ae470e05c883a69b10b023fef))
+
+### Enhancements made
+
+- Add support for base64 types [#20](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/20) ([@martinRenou](https://github.com/martinRenou))
+
+### Documentation improvements
+
+- Update README with docs and lite links [#29](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/29) ([@martinRenou](https://github.com/martinRenou))
+- Update documentation title [#28](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/28) ([@jtpio](https://github.com/jtpio))
+- Add docs [#27](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/27) ([@martinRenou](https://github.com/martinRenou))
+- Update links to point to the new repo [#25](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/25) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Disable rename and copy menus [#23](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/23) ([@martinRenou](https://github.com/martinRenou))
+- Implement delete [#15](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/15) ([@martinRenou](https://github.com/martinRenou))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-12&to=2022-04-15&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-filesystem-access+involves%3Ajtpio+updated%3A2022-04-12..2022-04-15&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-filesystem-access+involves%3AmartinRenou+updated%3A2022-04-12..2022-04-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.0
 
 ([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/compare/v0.2.0...8e56ca1c3ee5e81f725cf8b57198c5b6d301c935))
@@ -15,8 +43,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/graphs/contributors?from=2022-04-11&to=2022-04-12&type=c))
 
 [@martinRenou](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-filesystem-access+involves%3AmartinRenou+updated%3A2022-04-11..2022-04-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.2.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab-contrib/jupyterlab-filesystem-access  |
| Branch  | main  |
| Version Spec | 0.4.0 |
| Since | v0.3.0 |