### PR TITLE
Remove settings registry initilization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,6 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
-
 import { ToolbarButton } from '@jupyterlab/apputils';
 
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
@@ -21,13 +19,11 @@ import { FileSystemDrive } from './drive';
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab-filesystem-access:plugin',
   requires: [IFileBrowserFactory, ITranslator],
-  optional: [ISettingRegistry],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     browser: IFileBrowserFactory,
-    translator: ITranslator,
-    settingRegistry: ISettingRegistry | null
+    translator: ITranslator
   ) => {
     if (!window.showDirectoryPicker) {
       // bail if the browser does not support the File System API
@@ -35,10 +31,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
         'The File System Access API is not supported in this browser.'
       );
       return;
-    }
-
-    if (settingRegistry) {
-      settingRegistry.load(plugin.id);
     }
 
     const { serviceManager } = app;


### PR DESCRIPTION
The schemas were removed in https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/34/files#diff-d6222e54043036d3752c854adabd4732e2d2a6fae8588fcecd83e20e705a0570 so we don't need this anymore