### PR TITLE
Fix creating a new notebook

### DIFF
--- a/src/drive.ts
+++ b/src/drive.ts
@@ -160,7 +160,7 @@ export class FileSystemDrive implements Contents.IDrive {
       parentPath,
       type === 'directory' ? 'Untitled Folder' : 'untitled'
     );
-    const ext = options?.ext || 'txt';
+    const ext = type === 'notebook' ? 'ipynb' : options?.ext || 'txt';
 
     const parentHandle = await this.getParentHandle(path);
 


### PR DESCRIPTION
Fixes part of https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/issues/58

The other part of the fix is in JupyterLab: https://github.com/jupyterlab/jupyterlab/pull/15291

If `type` is specified and equals to `notebook`, default the file extension to `ipynb`.